### PR TITLE
Add ADRs to the imported documentation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,12 +6,22 @@ GovukTechDocs.configure(self)
 
 SERVICE_DOCS = [
   {
-    title: "Teacher Training API",
+    title: "Teacher Training API documentation",
     pages: GitHubRepoFetcher.instance.docs(
       service_name: "Teacher Training API",
       repo_name: "DFE-Digital/teacher-training-api",
       path_in_repo: "docs",
       path_prefix: "services/teacher-training-api",
+    ),
+  },
+  {
+    title: "Teacher Training API decisions",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Teacher Training API",
+      repo_name: "DFE-Digital/teacher-training-api",
+      path_in_repo: "docs/adr",
+      path_prefix: "services/teacher-training-api",
+      ignore_files: %w[index.md],
     ),
   },
   {
@@ -33,11 +43,30 @@ SERVICE_DOCS = [
     ),
   },
   {
-    title: "Apply for teacher training",
+    title: "Register trainee teachers decisions",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Register trainee teachers",
+      repo_name: "DFE-Digital/register-trainee-teachers",
+      path_in_repo: "docs/adr",
+      path_prefix: "services/register-trainee-teachers",
+      ignore_files: %w[index.md],
+    ),
+  },
+  {
+    title: "Apply for teacher training documentation",
     pages: GitHubRepoFetcher.instance.docs(
       service_name: "Apply for teacher training",
       repo_name: "DFE-Digital/apply-for-teacher-training",
       path_in_repo: "docs",
+      path_prefix: "services/apply-for-teacher-training",
+    ),
+  },
+  {
+    title: "Apply for teacher training decisions",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Apply for teacher training",
+      repo_name: "DFE-Digital/apply-for-teacher-training",
+      path_in_repo: "adr",
       path_prefix: "services/apply-for-teacher-training",
     ),
   },

--- a/lib/github_repo_fetcher.rb
+++ b/lib/github_repo_fetcher.rb
@@ -6,9 +6,9 @@ require "faraday_middleware"
 class GitHubRepoFetcher
   include Singleton
 
-  def docs(repo_name:, path_in_repo:, path_prefix:, service_name:)
+  def docs(repo_name:, path_in_repo:, path_prefix:, service_name:, ignore_files: [])
     directory_contents = client.contents(repo_name, path: path_in_repo)
-    markdown_files = directory_contents.select { |doc| doc.name.end_with?(".md") }
+    markdown_files = directory_contents.select { |doc| doc.name.end_with?(".md") && !doc.name.in?(ignore_files) }
 
     pages = markdown_files.map do |file|
       contents = HTTP.get_cached(file.download_url)

--- a/lib/github_repo_fetcher.rb
+++ b/lib/github_repo_fetcher.rb
@@ -37,9 +37,9 @@ class GitHubRepoFetcher
     pages.sort_by do |page|
       title = page.fetch(:title)
       # Because of lexicographical ordering, by default the ADRs would be ordered
-      # like 1, 10, 11, 12, 2, etc. To correcly order we need to translate the
-      # titles into integers. This will crash if some pages in the repo have
-      # leading numbers, and others have not.
+      # like 1, 10, 11, 12, 2, etc. To correctly order we need to translate the
+      # titles into integers. This will crash if some pages in the source directory
+      # have leading numbers, and others have not.
       first_integer = title.scan(/\d+/).first
       first_integer ? first_integer.to_i : title
     end

--- a/lib/github_repo_fetcher.rb
+++ b/lib/github_repo_fetcher.rb
@@ -33,7 +33,16 @@ class GitHubRepoFetcher
       }
     end
 
-    pages.sort_by { |page| page.fetch(:title) }
+    # Sort the pages by title.
+    pages.sort_by do |page|
+      title = page.fetch(:title)
+      # Because of lexicographical ordering, by default the ADRs would be ordered
+      # like 1, 10, 11, 12, 2, etc. To correcly order we need to translate the
+      # titles into integers. This will crash if some pages in the repo have
+      # leading numbers, and others have not.
+      first_integer = title.scan(/\d+/).first
+      first_integer ? first_integer.to_i : title
+    end
   end
 
 private

--- a/lib/github_repo_fetcher.rb
+++ b/lib/github_repo_fetcher.rb
@@ -11,7 +11,7 @@ class GitHubRepoFetcher
     markdown_files = directory_contents.select { |doc| doc.name.end_with?(".md") }
 
     pages = markdown_files.map do |file|
-      contents = HTTP.get(file.download_url)
+      contents = HTTP.get_cached(file.download_url)
       filename = file.name.match(/(.+)\..+$/)[1]
       title = ExternalDoc.title(contents) || filename
 

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -1,4 +1,12 @@
+CACHE = ActiveSupport::Cache::FileStore.new(".cache")
+
 module HTTP
+  def self.get_cached(url)
+    CACHE.fetch(url, expires_in: 1.hour) do
+      get(url)
+    end
+  end
+
   def self.get(url)
     uri = URI.parse(url)
 

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -1,10 +1,12 @@
-CACHE = ActiveSupport::Cache::FileStore.new(".cache")
-
 module HTTP
   def self.get_cached(url)
-    CACHE.fetch(url, expires_in: 1.hour) do
+    cache.fetch(url, expires_in: 1.hour) do
       get(url)
     end
+  end
+
+  def self.cache
+    @cache ||= ActiveSupport::Cache::FileStore.new(".cache")
   end
 
   def self.get(url)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -4,7 +4,7 @@ title: BAT tech team guide
 
 # BAT tech team guide
 
-Welcome to the guide for Become a Teacher tech team. This site is used internally in the Department for Education by the Candidate, ProVendor, and Publish & Register team.
+Welcome to the guide for Become a Teacher tech team. This site is used internally in the Department for Education by the Candidate, ProVendor, and Publish & Register teams.
 
 ## Service specific documentation
 


### PR DESCRIPTION
This makes it easier to view ADRs across the services.
