### PR TITLE
Add ability to configure main branch name from tech doc repos

### DIFF
--- a/lib/external_doc.rb
+++ b/lib/external_doc.rb
@@ -2,18 +2,18 @@ require "html/pipeline"
 require "uri"
 
 class ExternalDoc
-  def self.parse(markdown, repo_name: "", path: "")
+  def self.parse(markdown, repo_name: "", branch: "", path: "")
     context = {
       repository: repo_name,
       # Turn off hardbreaks as they behave different to github rendering
       gfm: false,
       base_url: URI.join(
         "https://github.com",
-        "#{repo_name}/blob/master/",
+        "#{repo_name}/blob/#{branch}/",
       ),
       image_base_url: URI.join(
         "https://raw.githubusercontent.com",
-        "#{repo_name}/master/",
+        "#{repo_name}/#{branch}/",
       ),
     }
 

--- a/lib/github_repo_fetcher.rb
+++ b/lib/github_repo_fetcher.rb
@@ -6,7 +6,7 @@ require "faraday_middleware"
 class GitHubRepoFetcher
   include Singleton
 
-  def docs(repo_name:, path_in_repo:, path_prefix:, service_name:, ignore_files: [])
+  def docs(repo_name:, branch: "master", path_in_repo:, path_prefix:, service_name:, ignore_files: [])
     directory_contents = client.contents(repo_name, path: path_in_repo)
     markdown_files = directory_contents.select { |doc| doc.name.end_with?(".md") && !doc.name.in?(ignore_files) }
 
@@ -22,7 +22,7 @@ class GitHubRepoFetcher
           locals: {
             service_name: service_name,
             title: title,
-            external_doc_contents: ExternalDoc.parse(contents, repo_name: repo_name, path: file.path),
+            external_doc_contents: ExternalDoc.parse(contents, repo_name: repo_name, branch: branch, path: file.path),
           },
           data: {
             # Title in search results

--- a/spec/external_doc_spec.rb
+++ b/spec/external_doc_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ExternalDoc do
         Capybara.string(described_class.parse(
           File.read("spec/fixtures/markdown.md"),
           repo_name: "alphagov/lipsum",
+          branch: "master",
           path: path,
         ).to_s)
       end


### PR DESCRIPTION
Apply will be deprecating master and moving to main.

In order to enable that transition, we need to ensure that the update documentation is retrieved in order for the tech-guide to be updated.
